### PR TITLE
ensure USER exists in env before accessing

### DIFF
--- a/ftransc/launcher.py
+++ b/ftransc/launcher.py
@@ -21,7 +21,7 @@ def cli():
     log_format = "[%(levelname)s] %(message)s"
     logging.basicConfig(stream=sys.stdout, level=log_level, format=log_format)
 
-    if os.environ["USER"] == "root":
+    if "USER" in os.environ and os.environ["USER"] == "root":
         raise SystemExit("It is not safe to run ftransc as root.")
 
     if not files and not opt.walk and not opt.cdrip:


### PR DESCRIPTION
Closes https://github.com/dopstar/ftransc/issues/8

This change makes it so that if `USER` is not set the script can still run.

I do however question the usefulness of checking if the user is root. Users running sudo or root should be presumed to understand the risks, and be allowed to do so. 